### PR TITLE
Progress Dialog in der globalen Suche und kleiner Bugfix

### DIFF
--- a/resources/lib/gui/hoster.py
+++ b/resources/lib/gui/hoster.py
@@ -405,7 +405,7 @@ class cHosterGui:
             count = 1
             for hoster in hosters:               
                 if self.dialog.iscanceled() or xbmc.abortRequested or check: return
-                percent = count/total*100
+                percent = count*100/total
                 try:
                     logger.info('try hoster %s' % hoster['name'])
                     # get stream links

--- a/xstream.py
+++ b/xstream.py
@@ -278,9 +278,15 @@ def searchGlobal():
     if (sSearchText != False and sSearchText != ''):
         aPlugins = []
         aPlugins = cPluginHandler().getAvailablePlugins()
+        oGui.dialog = xbmcgui.DialogProgress()
+        oGui.dialog.create('xStream',"Searching...")
+        numPlugins = len(aPlugins)
+        count = 0
         for pluginEntry in aPlugins:
             pluginName = str(pluginEntry['name'])
             pluginSiteName = pluginEntry['id']
+            oGui.dialog.update(count*100/numPlugins,'Searching: '+pluginName+'...')
+            count += 1
             logger.info('Searching for "'+sSearchText+'" at '+pluginName)
             try:
                 plugin = __import__(pluginSiteName, globals(), locals())
@@ -294,6 +300,7 @@ def searchGlobal():
                 logger.info(pluginName+': search failed')
                 import traceback
                 print traceback.format_exc()
+        oGui.dialog.close()
         oGui.setView()
         oGui.setEndOfDirectory()
     return True


### PR DESCRIPTION
Ich hab einen Progress Dialog zur globalen Suche hinzugefügt, die anzeigt, welches Plugin gerade abgefragt wird, so kann man schneller sehen, woran es gerade hängt.

Außerdem gab es einen kleinen Bug in einem Codeschnipsel, den ich kopiert hab und bei mir und an der originalen Stelle gefixt hab. Die Fortschrittsanzeige in hoster.py hat den Prozentsatz nicht korrekt berechnet.