### PR TITLE
Fix wrong parsing of some Hosters.

### DIFF
--- a/resources/lib/gui/hoster.py
+++ b/resources/lib/gui/hoster.py
@@ -45,6 +45,8 @@ class cHosterGui:
               
         if siteResult:
             sMediaUrl = siteResult['streamUrl']
+            if sMediaUrl[:8] == '/Out/?s=':
+                sMediaUrl = sMediaUrl[8:]
             logger.info('call play: ' + sMediaUrl)
             if siteResult['resolved']:
                 sLink = sMediaUrl


### PR DESCRIPTION
Hi Lynx,

einige der Hoster kann ich nicht abspielen (zb. DivXStage, weiß grad nicht, ob nur auf kinox oder auch auf anderen).

Ich hab mir die Logs und URLs durchgeschaut und gesehen, dass diese noch diesen Präfix vor der Hoster-Url haben: **/Out/?s=**

Hab mal einen Hotfix erstellt, vielleicht findest du ne bessere Lösung.

Gruß
Joe