### PR TITLE
Fix several issues with pluginHandler.py

### DIFF
--- a/resources/lib/handler/pluginHandler.py
+++ b/resources/lib/handler/pluginHandler.py
@@ -24,7 +24,6 @@ class cPluginHandler:
         fileNames = self.__getFileNamesFromFolder(self.defaultFolder)
         for fileName in fileNames:
             plugin = {'name':'', 'icon':'', 'settings':'','modified':0}
-            plugin.update(pluginDB[fileName])
             try:
                 modTime = os.path.getmtime( os.path.join(self.defaultFolder,fileName+'.py'))
             except OSError:
@@ -37,6 +36,7 @@ class cPluginHandler:
                     pluginData['modified'] = modTime
                     pluginDB[fileName] = pluginData
                     update = True
+            plugin.update(pluginDB[fileName])
         # check pluginDB for obsolete entries
         deletions = []
         for pluginID in pluginDB:
@@ -50,7 +50,7 @@ class cPluginHandler:
 
         return self.getAvailablePluginsFromDB()
 
-        
+
 
     def getAvailablePluginsFromDB(self):
         plugins = []
@@ -61,7 +61,7 @@ class cPluginHandler:
             plugin = pluginDB[pluginID]
             pluginSettingsName = 'plugin_%s' % pluginID
             plugin['id'] = pluginID
-            if plugin['icon']:
+            if 'icon' in plugin:
                 plugin['icon'] = os.path.join(iconFolder, plugin['icon'])
             else:
                 plugin['icon'] = ''
@@ -105,7 +105,7 @@ class cPluginHandler:
             return False
         pluginElements = pluginElem.findall('setting')
         for elem in pluginElements:
-            pluginElem.remove(elem)          
+            pluginElem.remove(elem)
         # add plugins to settings
         for pluginID in sorted(pluginData):
             plugin = pluginData[pluginID]
@@ -114,7 +114,7 @@ class cPluginHandler:
             attrib['id'] = 'plugin_%s' % pluginID
             attrib['label'] = plugin['name']
             ET.SubElement(pluginElem, 'setting', attrib)
-            if plugin['settings']:
+            if 'settings' in plugin:
                 customSettings = []
                 try:
                     customSettings = ET.XML(xmlString % plugin['settings']).findall('setting')
@@ -142,7 +142,7 @@ class cPluginHandler:
         pluginData = {}
         try:
             plugin = __import__(fileName, globals(), locals())
-            pluginData['name'] = plugin.SITE_NAME                       
+            pluginData['name'] = plugin.SITE_NAME
         except Exception, e:
             logger.error("Can't import plugin: %s :%s" % (fileName, e))
             return False

--- a/resources/lib/handler/pluginHandler.py
+++ b/resources/lib/handler/pluginHandler.py
@@ -24,6 +24,7 @@ class cPluginHandler:
         fileNames = self.__getFileNamesFromFolder(self.defaultFolder)
         for fileName in fileNames:
             plugin = {'name':'', 'icon':'', 'settings':'','modified':0}
+            plugin.update(pluginDB[fileName])
             try:
                 modTime = os.path.getmtime( os.path.join(self.defaultFolder,fileName+'.py'))
             except OSError:
@@ -36,7 +37,6 @@ class cPluginHandler:
                     pluginData['modified'] = modTime
                     pluginDB[fileName] = pluginData
                     update = True
-            plugin.update(pluginDB[fileName])
         # check pluginDB for obsolete entries
         deletions = []
         for pluginID in pluginDB:

--- a/resources/settings.xml
+++ b/resources/settings.xml
@@ -1,33 +1,19 @@
 <settings> 
     <category label="30021">       
-        <!--<setting default="false" id="debug" label="30000" type="bool" />-->
+        
         <setting default="false" id="autoPlay" label="30005" type="bool" />
         <setting default="100" id="maxHoster" label="maximale Laenge Hosterliste" type="number" />
-        <setting default="false" id="hosterListFolder" label="30007" type="bool" enable="eq(-2,false)"/>
-        <setting default="true" id="presortHoster" label="30009" type="bool" enable="eq(-3,false)"/>
+        <setting default="false" enable="eq(-2,false)" id="hosterListFolder" label="30007" type="bool" />
+        <setting default="true" enable="eq(-3,false)" id="presortHoster" label="30009" type="bool" />
         <setting default="2" id="prefLanguage" label="30002" type="enum" values="ger|eng|all" />
         <setting default="false" id="metahandler" label="30004" type="bool" />
-        <setting default="false" id="metaOverwrite" label="30008" type="bool" enable="!eq(-1,false)" />
+        <setting default="false" enable="!eq(-1,false)" id="metaOverwrite" label="30008" type="bool" />
         <setting default="600" id="cacheTime" label="30006" type="number" />
         <setting default="false" id="showAdult" label="30003" type="bool" />
         <setting type="sep" />
     </category> 
     <category label="30022">       
-        <setting default="false" id="plugin_bundesliga_de" label="Bundesliga.de" type="bool" />
-        <setting default="false" id="plugin_burning_series_org" label="Burning-Seri.es" type="bool" />
-        <setting default="false" id="plugin_gstream_in" label="G-Stream.in" type="bool" />
-        <setting default="" id="gstream_in-username" label="Benutzername" type="text" />
-        <setting default="" id="gstream_in-password" label="Passwort" type="text" option="hidden" />
-        <setting default="true" id="plugin_kinoleak" label="KinoLeak.tv" type="bool" />
-        <setting default="false" id="plugin_kinox_to" label="Kinox.to" type="bool" />
-        <setting default="kinox.to" enable="!eq(-1,false)" id="kinox_to-domain" label="Kinox domain" type="labelenum" values="kinox.to|kinox.me|kinox.tv" />
-        <setting default="false" id="plugin_kkiste_to" label="KKiste.to" type="bool" />
-        <setting default="false" id="plugin_movie4k_to" label="Movie4k.to" type="bool" />
-        <setting default="movie4k.to" enable="!eq(-1,false)" id="movie4k_to-domain" label="Movie4k domain" type="labelenum" values="movie4k.to|movie4k.me|movie4k.tv" />
-        <setting default="false" id="plugin_moviesever_com" label="MoviesEver.com" type="bool" />
-        <setting default="false" id="plugin_seriesever_net" label="SeriesEver.net" type="bool" />
-        <setting type="sep" />
-    </category>
+        <setting label="Bundesliga.de" type="lsep" /><setting default="false" id="plugin_bundesliga_de" label="Bundesliga.de" type="bool" /><setting label="Burning-Series" type="lsep" /><setting default="false" id="plugin_burning_series_org" label="Burning-Series" type="bool" /><setting label="G-Stream" type="lsep" /><setting default="false" id="plugin_gstream_in" label="G-Stream" type="bool" /><setting default="" id="gstream_in-username" label="Benutzername" type="text" />+                <setting default="" id="gstream_in-password" label="Passwort" option="hidden" type="text" /><setting label="KinoLeak.Tv" type="lsep" /><setting default="false" id="plugin_kinoleak" label="KinoLeak.Tv" type="bool" /><setting label="Kinox.to" type="lsep" /><setting default="false" id="plugin_kinox_to" label="Kinox.to" type="bool" /><setting default="kinox.to" enable="!eq(-1,false)" id="kinox_to-domain" label="Kinox domain" type="labelenum" values="kinox.to|kinox.me|kinox.tv" /><setting label="KKiste.to" type="lsep" /><setting default="false" id="plugin_kkiste_to" label="KKiste.to" type="bool" /><setting label="Movie4k.to" type="lsep" /><setting default="false" id="plugin_movie4k_to" label="Movie4k.to" type="bool" /><setting default="movie4k.to" enable="!eq(-1,false)" id="movie4k_to-domain" label="Movie4k domain" type="labelenum" values="movie4k.to|movie4k.me|movie4k.tv" /><setting label="MoviesEver" type="lsep" /><setting default="false" id="plugin_moviesever_com" label="MoviesEver" type="bool" /><setting label="SeriesEver" type="lsep" /><setting default="false" id="plugin_seriesever_net" label="SeriesEver" type="bool" /><setting label="Szene-Streams" type="lsep" /><setting default="false" id="plugin_szene-streams_com" label="Szene-Streams" type="bool" /></category>
     <category label="Views">
         <setting default="false" id="auto-view" label="automatische Views aktivieren" type="bool" />
         <setting default="503" enable="!eq(-1,false)" id="movies-view" label="Film-View" type="number" />
@@ -37,7 +23,7 @@
     </category>
     <category label="30024">
         <setting label="30080" type="sep" />
-        <setting id="download-folder" type="folder" label="30081" default=""/>
+        <setting default="" id="download-folder" label="30081" type="folder" />
         <setting label="30070" type="sep" />
         <setting default="false" id="jd_enabled" label="30071" type="bool" />
         <setting default="127.0.0.1" enable="!eq(-1,false)" id="jd_host" label="30072" type="text" />
@@ -49,6 +35,6 @@
         <setting default="127.0.0.1" enable="!eq(-1,false)" id="pyload_host" label="30072" type="text" />
         <setting default="8000" enable="!eq(-2,false)" id="pyload_port" label="30073" type="number" />
         <setting default="user" enable="!eq(-3,false)" id="pyload_user" label="30083" type="text" />
-        <setting default="" enable="!eq(-4,false)" id="pyload_passwd" label="30084" type="text" option="hidden" />
+        <setting default="" enable="!eq(-4,false)" id="pyload_passwd" label="30084" option="hidden" type="text" />
     </category> 
 </settings>


### PR DESCRIPTION
- plugin.update caused a KeyError when fileName was not a key. Just
  move it down after the if fileName not in... clause, which fills
  the missing key
- correct syntax for several key checks from if dictionary['key']
  to if 'key' in dictionary to resolve KeyErrors
- remove trailing whitespaces
- add newline at EOF