### PR TITLE
Improve code for xstream.py

### DIFF
--- a/xstream.py
+++ b/xstream.py
@@ -273,7 +273,7 @@ def searchGlobal():
     numPlugins = len(aPlugins)
     threads = []
     for count, pluginEntry in enumerate(aPlugins):
-        dialog.update(count*100/numPlugins,'Searching: '+str(pluginEntry['name'])+'...')
+        dialog.update((count+1)*100/numPlugins,'Searching: '+str(pluginEntry['name'])+'...')
         logger.info('Searching for %s at %s' % (sSearchText, pluginEntry['id']))
         t = threading.Thread(target=_pluginSearch, args=(pluginEntry,sSearchText,oGui))
         threads += [t]

--- a/xstream.py
+++ b/xstream.py
@@ -13,10 +13,8 @@ import sys
 def run():
     parseUrl()
 
-
 def changeWatched(params):
-    if not cConfig().getSetting('metahandler')=='true':
-        return
+    if not cConfig().getSetting('metahandler')=='true': return
     #videoType, name, imdbID, season=season, episode=episode, year=year, watched=watched
     try:
         from metahandler import metahandlers
@@ -58,23 +56,22 @@ def updateMeta(params):
     name = str(params.getValue('title'))
     year = params.getValue('year')
     logger.info("MediaType: "+mediaType)
-    if (mediaType == 'movie' or mediaType == 'tvshow') :
+    if mediaType == 'movie' or mediaType == 'tvshow':
         # show meta search input
         oGui = cGui()
         sSearchText = oGui.showKeyBoard(name)
-        if (sSearchText != False and sSearchText != ''):
-            if mediaType == 'movie':
-                try:
-                    foundInfo = meta.search_movies(sSearchText)
-                except:
-                    logger.info('error or nothing found')
-                    foundInfo = False
-            elif mediaType == 'tvshow':
-                foundInfo = metahandlers.TheTVDB().get_matching_shows(sSearchText, language="all")
-            else:
-                return
+        if not sSearchText: return
+        if mediaType == 'movie':
+            try:
+                foundInfo = meta.search_movies(sSearchText)
+            except:
+                logger.info('error or nothing found')
+                foundInfo = False
+        elif mediaType == 'tvshow':
+            foundInfo = metahandlers.TheTVDB().get_matching_shows(sSearchText, "all")
         else:
             return
+
         if not foundInfo:
             oGui.showInfo('xStream', 'Suchanfrage lieferte kein Ergebnis')
             return
@@ -116,36 +113,38 @@ def updateMeta(params):
     xbmc.executebuiltin("XBMC.Container.Refresh")
     return
 
-
 def parseUrl():
-  params = ParameterHandler()
+    params = ParameterHandler()
 
-  # If no function is set, we set it to the default "load" function
-  if params.exist('function'):
-    sFunction = params.getValue('function')
-    if sFunction == 'spacer':
-        return True
-    elif sFunction == 'clearCache':
-        from resources.lib.handler.requestHandler import cRequestHandler
-        cRequestHandler('dummy').clearCache()
-        return
-    elif sFunction == 'changeWatched':
-        changeWatched(params)
-        return
-    elif sFunction == 'updateMeta':
-        updateMeta(params)
-        return
-    elif sFunction == 'searchAlter':
-        searchAlter(params)
-        return
-  else:
-    sFunction = 'load'
+    # If no function is set, we set it to the default "load" function
+    if params.exist('function'):
+        sFunction = params.getValue('function')
+        if sFunction == 'spacer':
+            return True
+        elif sFunction == 'clearCache':
+            from resources.lib.handler.requestHandler import cRequestHandler
+            cRequestHandler('dummy').clearCache()
+            return
+        elif sFunction == 'changeWatched':
+            changeWatched(params)
+            return
+        elif sFunction == 'updateMeta':
+            updateMeta(params)
+            return
+        elif sFunction == 'searchAlter':
+            searchAlter(params)
+            return
+    else:
+      sFunction = 'load'
 
-  # Test if we should run a function on a special site
-  if params.exist('site'):
+    # Test if we should run a function on a special site
+    if not params.exist('site'):
+        xbmc.executebuiltin('XBMC.RunPlugin(%s?function=clearCache)' % sys.argv[0])
+        # As a default if no site was specified, we run the default starting gui with all plugins
+        showMainMenu(sFunction)
+        return
     sSiteName = params.getValue('site')
     logger.info (params.getAllParameters())
-
     if params.exist('playMode'):
         from resources.lib.gui.hoster import cHosterGui
         url = False
@@ -153,113 +152,99 @@ def parseUrl():
         isHoster = params.getValue('isHoster')
         url = params.getValue('url')
         manual = params.exist('manual')
-
         if cConfig().getSetting('autoPlay')=='true' and playMode != 'jd' and playMode != 'pyload' and not manual:
             cHosterGui().streamAuto(playMode, sSiteName, sFunction)
         else:
             cHosterGui().stream(playMode, sSiteName, sFunction, url)
         return
-
+    logger.info("Call function '%s' from '%s'" % (sFunction, sSiteName))
+    # If the hoster gui is called, run the function on it and return
+    if sSiteName == 'cHosterGui':
+        showHosterGui(sFunction)
+    # If global search is called
+    elif sSiteName == 'globalSearch':
+        searchGlobal()
+    elif sSiteName == 'favGui':
+        showFavGui(sFunction)
+    # If addon settings are called
+    elif sSiteName == 'xStream':
+        oGui = cGui()
+        oGui.openSettings()
+        oGui.updateDirectory()
+    # If the urlresolver settings are called
+    elif sSiteName == 'urlresolver':
+        import urlresolver
+        urlresolver.display_settings()
+    # If metahandler settings are called
+    elif sSiteName == 'metahandler':
+        import metahandler
+        metahandler.display_settings()
     else:
-        logger.info("Call function '%s' from '%s'" % (sFunction, sSiteName))
-        # If the hoster gui is called, run the function on it and return
-        if sSiteName == 'cHosterGui':
-            showHosterGui(sFunction)
-            return
-        # If global search is called
-        elif sSiteName == 'globalSearch':
-            searchGlobal()
-            return
-        elif sSiteName == 'favGui':
-            showFavGui(sFunction)
-            return
-        # If addon settings are called
-        elif sSiteName == 'xStream':
-            oGui = cGui()
-            oGui.openSettings()
-            oGui.updateDirectory()
-            return
-        # If the urlresolver settings are called
-        elif sSiteName == 'urlresolver':
-            import urlresolver
-            urlresolver.display_settings()
-            return
-        # If metahandler settings are called
-        elif sSiteName == 'metahandler':
-            import metahandler
-            metahandler.display_settings()
-            return
-        else:
-            # Else load any other site as plugin and run the function
-            plugin = __import__(sSiteName, globals(), locals())
-            function = getattr(plugin, sFunction)
-            function()
-
-  else:
-      xbmc.executebuiltin('XBMC.RunPlugin(%s?function=clearCache)' % sys.argv[0])
-      # As a default if no site was specified, we run the default starting gui with all plugins
-      showMainMenu(sFunction)
+        # Else load any other site as plugin and run the function
+        plugin = __import__(sSiteName, globals(), locals())
+        function = getattr(plugin, sFunction)
+        function()
 
 def showMainMenu(sFunction):
     oGui = cGui()
     oPluginHandler = cPluginHandler()
     aPlugins = oPluginHandler.getAvailablePlugins()
-    if len(aPlugins) <= 0:
-      logger.info("No Plugins found")
-      # Open the settings dialog to choose a plugin that could be enabled
-      oGui.openSettings()
-      oGui.updateDirectory()
+    if not aPlugins:
+        logger.info("No Plugins found")
+        # Open the settings dialog to choose a plugin that could be enabled
+        oGui.openSettings()
+        oGui.updateDirectory()
     else:
-      # Create a gui element for every plugin found
-      for aPlugin in aPlugins:
+        # Create a gui element for every plugin found
+        for aPlugin in aPlugins:
+            oGuiElement = cGuiElement()
+            oGuiElement.setTitle(aPlugin['name'])
+            oGuiElement.setSiteName(aPlugin['id'])
+            oGuiElement.setFunction(sFunction)
+            if 'icon' in aPlugin and aPlugin['icon']:
+                oGuiElement.setThumbnail(aPlugin['icon'])
+            oGui.addFolder(oGuiElement)
+
+        # Create a gui element for global search
         oGuiElement = cGuiElement()
-        oGuiElement.setTitle(aPlugin['name'])
-        oGuiElement.setSiteName(aPlugin['id'])
-        oGuiElement.setFunction(sFunction)
-        if aPlugin['icon'] != '':
-            oGuiElement.setThumbnail(aPlugin['icon'])
+        oGuiElement.setTitle("Globale Suche")
+        oGuiElement.setSiteName("globalSearch")
+        oGuiElement.setFunction("globalSearch")
+        #oGuiElement.setThumbnail("DefaultAddonService.png")
         oGui.addFolder(oGuiElement)
 
-      # Create a gui element for global search
-      oGuiElement = cGuiElement()
-      oGuiElement.setTitle("Globale Suche")
-      oGuiElement.setSiteName("globalSearch")
-      oGuiElement.setFunction("globalSearch")
-      #oGuiElement.setThumbnail("DefaultAddonService.png")
-      oGui.addFolder(oGuiElement)
+        # Create a gui element for favorites
+        #oGuiElement = cGuiElement()
+        #oGuiElement.setTitle("Favorites")
+        #oGuiElement.setSiteName("FavGui")
+        #oGuiElement.setFunction("showFavs")
+        #oGuiElement.setThumbnail("DefaultAddonService.png")
+        #oGui.addFolder(oGuiElement)
 
-      # Create a gui element for favorites
-      #oGuiElement = cGuiElement()
-      #oGuiElement.setTitle("Favorites")
-      #oGuiElement.setSiteName("FavGui")
-      #oGuiElement.setFunction("showFavs")
-      #oGuiElement.setThumbnail("DefaultAddonService.png")
-      #oGui.addFolder(oGuiElement)
+        # Create a gui element for addon settings
+        oGuiElement = cGuiElement()
+        oGuiElement.setTitle("xStream Settings")
+        oGuiElement.setSiteName("xStream")
+        oGuiElement.setFunction("display_settings")
+        oGuiElement.setThumbnail("DefaultAddonService.png")
+        oGui.addFolder(oGuiElement)
 
-      # Create a gui element for addon settings
-      oGuiElement = cGuiElement()
-      oGuiElement.setTitle("xStream Settings")
-      oGuiElement.setSiteName("xStream")
-      oGuiElement.setFunction("display_settings")
-      oGuiElement.setThumbnail("DefaultAddonService.png")
-      oGui.addFolder(oGuiElement)
+        # Create a gui element for urlresolver settings
+        oGuiElement = cGuiElement()
+        oGuiElement.setTitle("Resolver Settings")
+        oGuiElement.setSiteName("urlresolver")
+        oGuiElement.setFunction("display_settings")
+        oGuiElement.setThumbnail("DefaultAddonService.png")
+        oGui.addFolder(oGuiElement)
 
-      # Create a gui element for urlresolver settings
-      oGuiElement = cGuiElement()
-      oGuiElement.setTitle("Resolver Settings")
-      oGuiElement.setSiteName("urlresolver")
-      oGuiElement.setFunction("display_settings")
-      oGuiElement.setThumbnail("DefaultAddonService.png")
-      oGui.addFolder(oGuiElement)
-
-      if cConfig().getSetting('metahandler')=='true':
-      # Create a gui element for metahandler settings
-          oGuiElement = cGuiElement()
-          oGuiElement.setTitle("Metahandler Settings")
-          oGuiElement.setSiteName("metahandler")
-          oGuiElement.setFunction("display_settings")
-          oGuiElement.setThumbnail("DefaultAddonService.png")
-          oGui.addFolder(oGuiElement)
+        # Create a gui element for metahandler settings
+        if cConfig().getSetting('metahandler')=='true':
+            oGuiElement = cGuiElement()
+            oGuiElement.setTitle("Metahandler Settings")
+            oGuiElement.setSiteName("metahandler")
+            oGuiElement.setFunction("display_settings")
+            oGuiElement.setThumbnail("DefaultAddonService.png")
+            oGui.addFolder(oGuiElement)
     oGui.setEndOfDirectory()
 
 def showHosterGui(sFunction):
@@ -280,7 +265,7 @@ def searchGlobal():
     import threading
     oGui = cGui()
     sSearchText = oGui.showKeyBoard()
-    if (sSearchText != False and sSearchText != ''):
+    if sSearchText:
         aPlugins = []
         aPlugins = cPluginHandler().getAvailablePlugins()
         dialog = xbmcgui.DialogProgress()
@@ -341,7 +326,6 @@ def searchAlter(params):
     oGui.setEndOfDirectory()
     #xbmc.executebuiltin('Container.Update')
     return True
-
 
 def _pluginSearch(pluginEntry, sSearchText, oGui):
     try:

--- a/xstream.py
+++ b/xstream.py
@@ -83,7 +83,7 @@ def updateMeta(params):
         items = []
         for item in foundInfo:
             if mediaType == 'movie':
-                items.append(str(item['title'].encode('utf-8'))+' ('+str(item['year'])+')')                   
+                items.append(str(item['title'].encode('utf-8'))+' ('+str(item['year'])+')')
             elif mediaType == 'tvshow':
                 if len(item)>2:items.append(str(item[1])+' ('+str(item[3])+')')
                 else: items.append(str(item[1]))
@@ -101,7 +101,7 @@ def updateMeta(params):
         year = ''
     if mediaType == 'movie':
         meta.update_meta(mediaType, name, imdbID, new_imdb_id=str(item['imdb_id']), new_tmdb_id=str(item['tmdb_id']), year=year)
-    elif mediaType == 'tvshow': 
+    elif mediaType == 'tvshow':
         if params.exist('season'):
             season = params.getValue('season')
             meta.update_season(name, imdbID, season)
@@ -112,7 +112,7 @@ def updateMeta(params):
         elif season:
             meta.update_season(name, imdbID, season)
         else:
-            meta.update_meta(mediaType, name, imdbID, new_imdb_id=str(item[2]), new_tmdb_id=str(item[0]), year=year) 
+            meta.update_meta(mediaType, name, imdbID, new_imdb_id=str(item[2]), new_tmdb_id=str(item[0]), year=year)
     xbmc.executebuiltin("XBMC.Container.Refresh")
     return
 
@@ -133,10 +133,10 @@ def parseUrl():
         changeWatched(params)
         return
     elif sFunction == 'updateMeta':
-        updateMeta(params) 
+        updateMeta(params)
         return
     elif sFunction == 'searchAlter':
-        searchAlter(params) 
+        searchAlter(params)
         return
   else:
     sFunction = 'load'
@@ -145,46 +145,46 @@ def parseUrl():
   if params.exist('site'):
     sSiteName = params.getValue('site')
     logger.info (params.getAllParameters())
-    
+
     if params.exist('playMode'):
         from resources.lib.gui.hoster import cHosterGui
         url = False
         playMode = params.getValue('playMode')
         isHoster = params.getValue('isHoster')
         url = params.getValue('url')
-        manual = params.exist('manual')  
-           
+        manual = params.exist('manual')
+
         if cConfig().getSetting('autoPlay')=='true' and playMode != 'jd' and playMode != 'pyload' and not manual:
             cHosterGui().streamAuto(playMode, sSiteName, sFunction)
-        else:        
+        else:
             cHosterGui().stream(playMode, sSiteName, sFunction, url)
         return
-        
-    else:    
+
+    else:
         logger.info("Call function '%s' from '%s'" % (sFunction, sSiteName))
         # If the hoster gui is called, run the function on it and return
         if sSiteName == 'cHosterGui':
             showHosterGui(sFunction)
-            return  
-        # If global search is called  
+            return
+        # If global search is called
         elif sSiteName == 'globalSearch':
             searchGlobal()
-            return    
+            return
         elif sSiteName == 'favGui':
             showFavGui(sFunction)
-            return 
-        # If addon settings are called  
+            return
+        # If addon settings are called
         elif sSiteName == 'xStream':
             oGui = cGui()
             oGui.openSettings()
             oGui.updateDirectory()
             return
-        # If the urlresolver settings are called  
+        # If the urlresolver settings are called
         elif sSiteName == 'urlresolver':
             import urlresolver
             urlresolver.display_settings()
             return
-        # If metahandler settings are called    
+        # If metahandler settings are called
         elif sSiteName == 'metahandler':
             import metahandler
             metahandler.display_settings()
@@ -194,13 +194,13 @@ def parseUrl():
             plugin = __import__(sSiteName, globals(), locals())
             function = getattr(plugin, sFunction)
             function()
-    
+
   else:
       xbmc.executebuiltin('XBMC.RunPlugin(%s?function=clearCache)' % sys.argv[0])
       # As a default if no site was specified, we run the default starting gui with all plugins
       showMainMenu(sFunction)
 
-def showMainMenu(sFunction):    
+def showMainMenu(sFunction):
     oGui = cGui()
     oPluginHandler = cPluginHandler()
     aPlugins = oPluginHandler.getAvailablePlugins()
@@ -219,7 +219,7 @@ def showMainMenu(sFunction):
         if aPlugin['icon'] != '':
             oGuiElement.setThumbnail(aPlugin['icon'])
         oGui.addFolder(oGuiElement)
-      
+
       # Create a gui element for global search
       oGuiElement = cGuiElement()
       oGuiElement.setTitle("Globale Suche")
@@ -227,7 +227,7 @@ def showMainMenu(sFunction):
       oGuiElement.setFunction("globalSearch")
       #oGuiElement.setThumbnail("DefaultAddonService.png")
       oGui.addFolder(oGuiElement)
-        
+
       # Create a gui element for favorites
       #oGuiElement = cGuiElement()
       #oGuiElement.setTitle("Favorites")
@@ -243,7 +243,7 @@ def showMainMenu(sFunction):
       oGuiElement.setFunction("display_settings")
       oGuiElement.setThumbnail("DefaultAddonService.png")
       oGui.addFolder(oGuiElement)
-      
+
       # Create a gui element for urlresolver settings
       oGuiElement = cGuiElement()
       oGuiElement.setTitle("Resolver Settings")
@@ -251,7 +251,7 @@ def showMainMenu(sFunction):
       oGuiElement.setFunction("display_settings")
       oGuiElement.setThumbnail("DefaultAddonService.png")
       oGui.addFolder(oGuiElement)
-      
+
       if cConfig().getSetting('metahandler')=='true':
       # Create a gui element for metahandler settings
           oGuiElement = cGuiElement()
@@ -268,7 +268,7 @@ def showHosterGui(sFunction):
     function = getattr(oHosterGui, sFunction)
     function()
     return True
-  
+
 #def showFavGui(functionName):
     #from resources.lib.gui.favorites import FavGui
     #oFavGui = FavGui()
@@ -295,7 +295,7 @@ def searchGlobal():
             t = threading.Thread(target=_pluginSearch, args=(pluginEntry,sSearchText,oGui))
             threads += [t]
             t.start()
-        for t in threads: 
+        for t in threads:
             t.join()
         dialog.close()
         oGui.setView()
@@ -322,7 +322,7 @@ def searchAlter(params):
         t = threading.Thread(target=_pluginSearch, args=(pluginEntry,searchTitle, oGui))
         threads += [t]
         t.start()
-    for t in threads: 
+    for t in threads:
         t.join()
     #check results, put this to the threaded part, too
     dialog.close()

--- a/xstream.py
+++ b/xstream.py
@@ -265,26 +265,24 @@ def searchGlobal():
     import threading
     oGui = cGui()
     sSearchText = oGui.showKeyBoard()
-    if sSearchText:
-        aPlugins = []
-        aPlugins = cPluginHandler().getAvailablePlugins()
-        dialog = xbmcgui.DialogProgress()
-        dialog.create('xStream',"Searching...")
-        numPlugins = len(aPlugins)
-        count = 0
-        threads = []
-        for pluginEntry in aPlugins:
-            dialog.update(count*100/numPlugins,'Searching: '+str(pluginEntry['name'])+'...')
-            count += 1
-            logger.info('Searching for %s at %s' % (sSearchText, pluginEntry['id']))
-            t = threading.Thread(target=_pluginSearch, args=(pluginEntry,sSearchText,oGui))
-            threads += [t]
-            t.start()
-        for t in threads:
-            t.join()
-        dialog.close()
-        oGui.setView()
-        oGui.setEndOfDirectory()
+    if not sSearchText: return True
+    aPlugins = []
+    aPlugins = cPluginHandler().getAvailablePlugins()
+    dialog = xbmcgui.DialogProgress()
+    dialog.create('xStream',"Searching...")
+    numPlugins = len(aPlugins)
+    threads = []
+    for count, pluginEntry in enumerate(aPlugins):
+        dialog.update(count*100/numPlugins,'Searching: '+str(pluginEntry['name'])+'...')
+        logger.info('Searching for %s at %s' % (sSearchText, pluginEntry['id']))
+        t = threading.Thread(target=_pluginSearch, args=(pluginEntry,sSearchText,oGui))
+        threads += [t]
+        t.start()
+    for t in threads:
+        t.join()
+    dialog.close()
+    oGui.setView()
+    oGui.setEndOfDirectory()
     return True
 
 def searchAlter(params):

--- a/xstream.py
+++ b/xstream.py
@@ -296,11 +296,9 @@ def searchAlter(params):
     dialog = xbmcgui.DialogProgress()
     dialog.create('xStream',"Searching...")
     numPlugins = len(aPlugins)
-    count = 0
     threads = []
-    for pluginEntry in aPlugins:
-        dialog.update(count*100/numPlugins,'Searching: '+str(pluginEntry['name'])+'...')
-        count += 1
+    for count, pluginEntry in enumerate(aPlugins):
+        dialog.update((count+1)*100/numPlugins,'Searching: '+str(pluginEntry['name'])+'...')
         logger.info('Searching for ' + searchTitle + pluginEntry['id'].encode('utf-8'))
         t = threading.Thread(target=_pluginSearch, args=(pluginEntry,searchTitle, oGui))
         threads += [t]


### PR DESCRIPTION
- Remove trailing whitespaces
- Add newline at EOF
- Remove unneeded parenthesis around if conditions
- Collapse string check for sSearchText (see 821c2e for reference)
- Reduce level of indent by exiting functions earlier
- Unify level of indents (sometimes 2 spaces were used and sometimes 4)
- Improve if logic in parseUrl by moving the last else statement for
  params.exist('site') up and reversing it's logic. Furthermore remove
  each return call for the following elifs as they are not needed
  anymore
- Simplify if condition for checking an empty dictionary
  (len(aPlugins) <= 0 to not aPlugins). As an empty dictionary
  defaults to False [1]
- Use enumerate instead of manually counting each for loop entrance
  for searchGlobal and searchAlter

[1] https://docs.python.org/2/library/stdtypes.html#truth-value-testing