### PR TITLE
hdfilme.tv: fix multihoster-support for some movies

### DIFF
--- a/sites/hdfilme_tv.py
+++ b/sites/hdfilme_tv.py
@@ -316,8 +316,8 @@ def getHosters(sUrl = False):
         # Server-Block durchlaufen
         for sServername, sInnerHtml in aResult[1]:
             # Nur Links für die gewünschte Episode ermitteln
-            pattern = "<a[^>]*href=['\"]([^'\"]*)['\"][^>]*>\s+%s\s+</a>" % sEpisode
-            aResultLinks = parser.parse(sInnerHtml, pattern)
+            pattern = "<a[^>]*href=['\"]([^'\"]*)['\"][^>]*>\s+(?:%s|HD|SD)\s+</a>" % sEpisode
+            aResultLinks = parser.parse(sInnerHtml, pattern, ignoreCase = True)
 
             # Wurde ein Link gefunden? => Einträge zur Gesamtliste hinzufügen
             if aResultLinks[0]:


### PR DESCRIPTION
some Movies use "1" and one use "HD" and "SD" (not really sure about SD)