### PR TITLE
anime-loads.org API Changed: fixed javascript URL and sitekey parser.

### DIFF
--- a/README.md
+++ b/README.md
@@ -405,3 +405,5 @@ In folgenden Ordnern sind die Kodi-Addons abgelegt:
 Das Addon xStream wird in aller Regel unter plugin.video.xstream istalliert.
 Im Verzeichnis `sites/` sind die .py Daten und im Ordner `resources/art/sites/` die jeweiligen Artworks bzw. Site-Icons der einzelnen Webseiten abgelegt.
 
+Info für den URL Resolver:
+https://github.com/Twilight0/repo.twilight0

--- a/README.md
+++ b/README.md
@@ -89,6 +89,10 @@ Alternativ könnte die xStream-Repository ebenfalls über das _SuperRepo_ gelade
 
 **WICHTIG:**Jedoch muss an dieser Stelle klar darauf hingewiesen werden, dass unter der alternativen Bezugsquelle nicht für den aktuellsten Stand der Software garantiert werden kann!
 
+**WICHTIG**Um AnimeLoads.org zu verwenden wird ein Update des URL resolvers benötigt, den ihr hier herunterladen könnt:
+
+- [Master-Branch bei GitHub] (https://github.com/tknorris/script.module.urlresolver/archive/master.zip)
+
 
 xStream-Repository aus Forum:
 
@@ -404,6 +408,3 @@ In folgenden Ordnern sind die Kodi-Addons abgelegt:
 
 Das Addon xStream wird in aller Regel unter plugin.video.xstream istalliert.
 Im Verzeichnis `sites/` sind die .py Daten und im Ordner `resources/art/sites/` die jeweiligen Artworks bzw. Site-Icons der einzelnen Webseiten abgelegt.
-
-Info für den URL Resolver:
-https://github.com/Twilight0/repo.twilight0

--- a/README.md
+++ b/README.md
@@ -89,7 +89,7 @@ Alternativ könnte die xStream-Repository ebenfalls über das _SuperRepo_ gelade
 
 **WICHTIG:**Jedoch muss an dieser Stelle klar darauf hingewiesen werden, dass unter der alternativen Bezugsquelle nicht für den aktuellsten Stand der Software garantiert werden kann!
 
-**WICHTIG**Um AnimeLoads.org zu verwenden wird ein Update des URL resolvers benötigt, den ihr hier herunterladen könnt:
+**WICHTIG:**Um AnimeLoads.org zu verwenden wird ein Update des URL resolvers benötigt, den ihr hier herunterladen könnt:
 
 - [Master-Branch bei GitHub] (https://github.com/tknorris/script.module.urlresolver/archive/master.zip)
 

--- a/sites/anime-loads_org.py
+++ b/sites/anime-loads_org.py
@@ -300,11 +300,11 @@ def _uncaptcha():
 
 def _getSiteKey():
     sHtmlContent = _getRequestHandler(URL_MAIN, True).request()
-    pattern = '<script [^>]*src="([^"]*basic.min.js[^"]*)"[^>]*></script[>].*?'
+    pattern = '<script [^>]*src="([^"]*basic.js[^"]*)"[^>]*></script[>].*?'
     aResult = cParser().parse(sHtmlContent, pattern)
     if aResult[0]:
         sHtmlContent = _getRequestHandler(aResult[1][0], True).request()
-        aResult = cParser().parse(sHtmlContent, "'sitekey':'(.*?)'")
+        aResult = cParser().parse(sHtmlContent, "'sitekey' : '(.*?)'")
         if aResult[0]:
             return aResult[1][0]
         else:

--- a/sites/anime-loads_org.py
+++ b/sites/anime-loads_org.py
@@ -300,11 +300,11 @@ def _uncaptcha():
 
 def _getSiteKey():
     sHtmlContent = _getRequestHandler(URL_MAIN, True).request()
-    pattern = '<script [^>]*src="([^"]*basic.js[^"]*)"[^>]*></script[>].*?'
+    pattern = '<script [^>]*src="([^"]*basic.(?:min.)?js[^"]*)"[^>]*></script[>].*?'
     aResult = cParser().parse(sHtmlContent, pattern)
     if aResult[0]:
         sHtmlContent = _getRequestHandler(aResult[1][0], True).request()
-        aResult = cParser().parse(sHtmlContent, "'sitekey' : '(.*?)'")
+        aResult = cParser().parse(sHtmlContent, "'sitekey'\s?:\s?'(.*?)'")
         if aResult[0]:
             return aResult[1][0]
         else:


### PR DESCRIPTION
As mentioned in your issue tracker here the fix for the animeloads.org plugin.

Requirements: URLResolver 3.0.5