### PR TITLE
Added progess dialog to global search

### DIFF
--- a/xstream.py
+++ b/xstream.py
@@ -327,10 +327,8 @@ def searchGlobal():
     total=len(oGui.searchResults)
     dialog = xbmcgui.DialogProgress()
     dialog.create('xStream',"Gathering info...")
-    count=0
-    for result in sorted(oGui.searchResults, key=lambda k: k['guiElement'].getSiteName()):
+    for count,result in enumerate(sorted(oGui.searchResults, key=lambda k: k['guiElement'].getSiteName()),1):
         oGui.addFolder(result['guiElement'],result['params'],bIsFolder=result['isFolder'],iTotal=total)
-        count = count + 1
         dialog.update((count)*100/total, str(count)+' of '+str(total)+': '+result['guiElement'].getTitle())
     dialog.close()
     oGui.setView()

--- a/xstream.py
+++ b/xstream.py
@@ -325,8 +325,14 @@ def searchGlobal():
     # deactivate collectMode attribute because now we want the elements really added
     oGui._collectMode = False
     total=len(oGui.searchResults)
+    dialog = xbmcgui.DialogProgress()
+    dialog.create('xStream',"Gathering info...")
+    count=0
     for result in sorted(oGui.searchResults, key=lambda k: k['guiElement'].getSiteName()):
         oGui.addFolder(result['guiElement'],result['params'],bIsFolder=result['isFolder'],iTotal=total)
+        count = count + 1
+        dialog.update((count)*100/total, str(count)+' of '+str(total)+': '+result['guiElement'].getTitle())
+    dialog.close()
     oGui.setView()
     oGui.setEndOfDirectory()
     return True


### PR DESCRIPTION
GlobalSearch can take a long time, especially when using Metahandler. To give the user more feedback what is going on I added another progress dialog after the plugin searches returned.
