### PR TITLE
Library integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@
     - [2.3 Webseiten Aktivieren und Deaktivieren](#23-webseiten-aktivieren-und-deaktivieren)
     - [2.4 Manuelle und automatische Hosterwahl](#24-manuelle-und-automatische-hosterwahl)
     - [2.5 Funktion des Metahandlers](#25-funktion-des-metahandlers)
+    - [2.6 Library Integration](#26-library-integration)
  
  
 - [3. Bekannte Probleme](#3-bekannte-probleme)
@@ -170,7 +171,17 @@ Für schwache Systeme ist dieses Feature nur bedingt zu empfehlen und muss vom j
 
 - ***ACHTUNG:*** Da viele Seiten nicht sofort genug Informationen bereitstellen um jeden Film eindeutig zu identifizieren kann es vorkommen, dass alle angezeigten Informationen nicht zum tatsächlich verlinkten Film passen.
 
+### 2.6 Library Integration
 
+Wenn die Library Funktionen von Kodi benutzt werden sollen, kann die Option:
+
+- **STRM Dateien bei der Suche erzeugen**
+
+eingeschaltet werden. Dabei muss ein Verzeichnis angegeben werden, in welchem xStream für alle angezeigten Filme und Serien .strm Dateien ablegt. Es ist dringend angeraten ein Verzeichnis für die alleinige Verwendung durch xStream und außerhalb der eigentlichen Kodi Library anzulegen, da xStream in diesem Verzeichnis auch Dateien überschreibt. Innerhalb dieses Verzeichnisses legt xStream zwei Ordner an: Movies und TVShows. Diese können dann manuell zu der Kodi Library hinzugefügt werden.
+
+- ***ACHTUNG:*** Es werden ALLE Filme zu der Library hinzugefügt, auch erotische Inhalte.
+
+Die generierten .strm Dateien werden, falls der Film erneut in xStream angezeigt wird, nach 30 Tagen mit einem neuen Stream überschrieben, um veralteten Links entgegen zu wirken.
 
 ## 3. Bekannte Probleme
 

--- a/resources/language/English/strings.xml
+++ b/resources/language/English/strings.xml
@@ -35,6 +35,10 @@
   <string id="30082">PyLoad on/off</string>
   <string id="30083">Username</string>
   <string id="30084">Password</string>
+
+  <!-- Streamgenerator begins at 30090 -->
+  <string id="30090">Create STRM files while searching</string>
+  <string id="30091">Folder for STRM files</string>
   
   <string id="30302">Seasons german</string>
   <string id="30303">Seasons english</string>

--- a/resources/language/German/strings.xml
+++ b/resources/language/German/strings.xml
@@ -36,6 +36,9 @@
   <string id="30083">Benutzername</string>
   <string id="30084">Passwort</string>
   
+  <!-- Streamgenerator begins at 30090 -->
+  <string id="30090">STRM Dateien bei der Suche erzeugen</string>
+  <string id="30091">Ordner für STRM Dateien</string>
   
   <string id="30302">Staffeln Deutsch</string>
   <string id="30303">Staffeln Englisch</string>

--- a/resources/lib/gui/gui.py
+++ b/resources/lib/gui/gui.py
@@ -4,6 +4,7 @@ from resources.lib.config import cConfig
 from resources.lib.handler.ParameterHandler import ParameterHandler
 from resources.lib.gui.guiElement import cGuiElement
 from resources.lib import common
+from resources.lib import libraryIntegration
 
 import xbmc
 import xbmcgui
@@ -80,6 +81,9 @@ class cGui:
                  
         if not bIsFolder:
             oListItem.setProperty('IsPlayable', 'true')        
+            if cConfig().getSetting('generateStrms')=='true':
+                oStrmFile = libraryIntegration.cLibraryIntegration()
+                oStrmFile.write(oGuiElement, sItemUrl)
         xbmcplugin.addDirectoryItem(self.pluginHandle, sItemUrl, oListItem, isFolder = bIsFolder, totalItems = iTotal)
         
 

--- a/resources/lib/libraryIntegration.py
+++ b/resources/lib/libraryIntegration.py
@@ -6,6 +6,7 @@ import urllib
 import os
 import xbmc
 import time
+import re
 
 class cLibraryIntegration:
 
@@ -15,12 +16,12 @@ class cLibraryIntegration:
         self.__sRelPath = ''
         self.__sContent = ''
 
-    def __mangleFilename(self):
-        self.__sFilename = self.__sFilename.replace(":"," - ")
-        self.__sFilename = self.__sFilename.replace("/","-")
-
     def __buildFilename(self, oGuiElement, itemValues):
         sTitle = oGuiElement.getTitle().strip()
+        sTitle = re.sub(' \(.*\)', '', sTitle)
+        sTitle = sTitle.replace(":"," - ")
+        sTitle = sTitle.replace("/","-")
+        sTitle = ' '.join(sTitle.split())
         sMediaType = oGuiElement._mediaType
         if sMediaType == 'movie':
             self.__sRelPath = 'Movies/'
@@ -56,6 +57,5 @@ class cLibraryIntegration:
         itemValues = oGuiElement.getItemValues()
         self.__sContent = sItemUrl
         self.__buildFilename(oGuiElement, itemValues)
-        self.__mangleFilename()
         self.__writeFile()
 

--- a/resources/lib/libraryIntegration.py
+++ b/resources/lib/libraryIntegration.py
@@ -1,0 +1,53 @@
+# -*- coding: utf-8 -*-
+from resources.lib.config import cConfig
+from resources.lib.gui.guiElement import cGuiElement
+from resources.lib import logger
+import urllib
+import os
+import xbmc
+
+class cLibraryIntegration:
+
+    def __init__(self):
+        self.__sFilename = 'empty.strm'
+        self.__sStrmDir = cConfig().getSetting('StrmFolder')
+        self.__sRelPath = ''
+        self.__sContent = ''
+
+    def __mangleFilename(self):
+        self.__sFilename = self.__sFilename.replace(":"," - ")
+
+    def __buildFilename(self, oGuiElement, itemValues):
+        sTitle = oGuiElement.getTitle()
+        sMediaType = oGuiElement._mediaType
+        if sMediaType == 'movie':
+            logger.info("isMovie")
+            self.__sRelPath = 'Movies/'
+        elif sMediaType == 'episode':
+            logger.info("isEpisode")
+            sSeason = itemValues['season']
+            sEpisode = itemValues['episode']
+            sTVShowTitle = itemValues['TVShowTitle']
+            self.__sRelPath = 'TVShows/' + sTVShowTitle + '/Staffel ' + sSeason
+            sTitle = '/S' + sSeason + 'E' + sTitle
+
+        self.__sFilename = sTitle + '.strm'
+
+    def __writeFile(self):
+        sAbsPath = self.__sStrmDir + self.__sRelPath
+        sAbsPath = xbmc.translatePath(sAbsPath)
+        if not os.path.isdir(sAbsPath):
+            os.makedirs(os.path.join(sAbsPath))
+        sFullFilename = sAbsPath + self.__sFilename
+        if not os.path.isfile(sFullFilename):
+            fStrmFile = open(sFullFilename, 'w')
+            fStrmFile.write(self.__sContent + '\n') 
+            fStrmFile.close() 
+
+    def write(self, oGuiElement, sItemUrl):
+        itemValues = oGuiElement.getItemValues()
+        self.__sContent = sItemUrl
+        self.__buildFilename(oGuiElement, itemValues)
+        self.__mangleFilename()
+        self.__writeFile()
+

--- a/resources/lib/libraryIntegration.py
+++ b/resources/lib/libraryIntegration.py
@@ -23,15 +23,19 @@ class cLibraryIntegration:
         sTitle = sTitle.replace("/","-")
         sTitle = ' '.join(sTitle.split())
         sMediaType = oGuiElement._mediaType
-        if sMediaType == 'movie':
-            self.__sRelPath = 'Movies/'
-        elif sMediaType == 'episode':
+        if sMediaType == 'episode':
             logger.info("isEpisode")
             sSeason = itemValues['season']
             sEpisode = itemValues['episode']
             sTVShowTitle = itemValues['TVShowTitle']
             self.__sRelPath = 'TVShows/' + sTVShowTitle + '/Staffel ' + sSeason
-            sTitle = '/S' + sSeason + 'E' + sTitle
+            sTitle = '/S' + sSeason + 'E' + sEpisode + ' - ' + sTitle
+        else:
+            pattern = re.compile('[\W_]+', re.UNICODE)
+            sDirTitle = pattern.sub('', sTitle.lower())
+            sDirA = sDirTitle[0]
+            sDirB = sDirTitle[1]
+            self.__sRelPath = 'Movies/' + sDirA + '/' + sDirB + '/' 
 
         self.__sFilename = sTitle + '.strm'
 

--- a/resources/lib/libraryIntegration.py
+++ b/resources/lib/libraryIntegration.py
@@ -5,6 +5,7 @@ from resources.lib import logger
 import urllib
 import os
 import xbmc
+import time
 
 class cLibraryIntegration:
 
@@ -16,12 +17,12 @@ class cLibraryIntegration:
 
     def __mangleFilename(self):
         self.__sFilename = self.__sFilename.replace(":"," - ")
+        self.__sFilename = self.__sFilename.replace("/","-")
 
     def __buildFilename(self, oGuiElement, itemValues):
-        sTitle = oGuiElement.getTitle()
+        sTitle = oGuiElement.getTitle().strip()
         sMediaType = oGuiElement._mediaType
         if sMediaType == 'movie':
-            logger.info("isMovie")
             self.__sRelPath = 'Movies/'
         elif sMediaType == 'episode':
             logger.info("isEpisode")
@@ -43,6 +44,13 @@ class cLibraryIntegration:
             fStrmFile = open(sFullFilename, 'w')
             fStrmFile.write(self.__sContent + '\n') 
             fStrmFile.close() 
+        else:
+            # replace old strm files once in a while
+            if time.time() - os.path.getmtime(sFullFilename) > (3 * 30 * 24 * 60 * 60):
+                fStrmFile = open(sFullFilename, 'w')
+                fStrmFile.truncate()
+                fStrmFile.write(self.__sContent + '\n')
+                fStrmFile.close()
 
     def write(self, oGuiElement, sItemUrl):
         itemValues = oGuiElement.getItemValues()

--- a/resources/settings.xml
+++ b/resources/settings.xml
@@ -12,6 +12,8 @@
     <setting default="false" enable="!eq(-1,false)" id="metaOverwrite" label="30008" type="bool" />
     <setting default="600" id="cacheTime" label="30006" type="number" />
     <setting default="false" id="showAdult" label="30003" type="bool" />
+    <setting default="false" id="generateStrms" label="30090" type="bool" />
+    <setting default="/tmp" id="StrmFolder" label="30091" option="writeable" source="auto" type="folder" />
     <setting type="sep" />
   </category> 
   <category label="30022">
@@ -75,3 +77,4 @@
     <setting default="" enable="!eq(-4,false)" id="pyload_passwd" label="30084" option="hidden" type="text" />
   </category> 
 </settings>
+

--- a/resources/settings.xml
+++ b/resources/settings.xml
@@ -13,7 +13,7 @@
     <setting default="600" id="cacheTime" label="30006" type="number" />
     <setting default="false" id="showAdult" label="30003" type="bool" />
     <setting default="false" id="generateStrms" label="30090" type="bool" />
-    <setting default="/tmp" id="StrmFolder" label="30091" option="writeable" source="auto" type="folder" />
+    <setting default="/tmp" enable="!eq(-1,false)" id="StrmFolder" label="30091" option="writeable" source="auto" type="folder" />
     <setting type="sep" />
   </category> 
   <category label="30022">


### PR DESCRIPTION
Hi Lynx,

ich habe einen Entwurf für die Library Integration gemacht. Der Umgang mit PseudoLibrary ist einfach zu fehleranfällig und umständlich. Ich habe die Erzeugung der .strm Dateien in xStream eingebaut, da so die Filme, nach denen man sucht oder durch die man in den Site Plugins browst auch in der Library landen.

Bezüglich der Implementation bin ich mir aber an zwei Stellen nicht sicher:
1. Sollte der User den Metahandler nicht enabled haben, werden alle Funde als "Movies" angelegt. Sollte ich deshalb meine Konfigurationsoptionen nur dann enablen, wenn der Metahandler enabled ist?

2. Leider gibt es keine einfache Möglichkeit XXX-Filme auszufiltern. Sollte ich deshalb meine Konfigurationsoptionen nur dann enablen, wenn showAdult disabled ist? Andererseits wäre das irgendwie auch eine Bevormundung des Users...

Ansonsten hoffe ich, dass es in Deinem Sinne ist, das Feature einzubauen.
